### PR TITLE
Update commons-io:commons-io from 2.16.1 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <version.commons-codec>1.17.1</version.commons-codec>
     <version.commons-dbcp2>2.12.0</version.commons-dbcp2>
     <version.commons-discovery>0.5</version.commons-discovery>
-    <version.commons-io>2.16.1</version.commons-io>
+    <version.commons-io>2.17.0</version.commons-io>
     <version.commons-lang3>3.16.0</version.commons-lang3>
     <version.commons-net>3.11.1</version.commons-net>
     <version.commons-pool>2.12.0</version.commons-pool>


### PR DESCRIPTION
Bumps commons-io:commons-io from 2.16.1 to 2.17.0.
- see: https://commons.apache.org/proper/commons-io/changes-report.html#a2.17.0